### PR TITLE
Add pip upgrade to installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ deployment goals without "throwing the model over the fence and back".
   conda create -n octoml python=3.8
   conda activate octoml
   ```
+- Ensure pip is up to date
+   ```
+   pip install --upgrade pip
+   ```
 
 - Install torch2.0 stable version
   ```


### PR DESCRIPTION
Otherwise, users might see this when trying an experimental torch version

```
ERROR: Could not find a version that satisfies the requirement torch==2.1.0.dev20230307 (from versions: 2.0.0.dev20230125+cpu)
ERROR: No matching distribution found for torch==2.1.0.dev20230307
```